### PR TITLE
Fixes token generation keyname mismatch (NFS-249)

### DIFF
--- a/src/lib/SSOToken.js
+++ b/src/lib/SSOToken.js
@@ -12,16 +12,16 @@ class SSOToken {
 	 * @param {String} tokenData Signed Token Data to be decoded
 	 */
 	constructor(audience, appSecret, tokenData) {
-    // Check validity of audience
-    if (audience === undefined || audience === null) {
-      throw new Error('Audience null or not specified');
-    }
-    if (typeof audience !== 'string') {
-      throw new Error('Audience must be a string value');
-    }
-    if (!audience.trim()) {
-      throw new Error('Audience cannot be an empty string');
-    }
+		// Check validity of audience
+		if (audience === undefined || audience === null) {
+			throw new Error('Audience null or not specified');
+		}
+		if (typeof audience !== 'string') {
+			throw new Error('Audience must be a string value');
+		}
+		if (!audience.trim()) {
+			throw new Error('Audience cannot be an empty string');
+		}
 
 		// Check Validity of appSecret
 		if (appSecret === undefined || appSecret === null) {
@@ -55,7 +55,7 @@ class SSOToken {
 			};
 			decoded = jwt.verify(tokenData, appSecret, jwtOpts);
 			// console.log('Decoded Data:', decoded);
-		} catch(err) {
+		} catch (err) {
 			if (err.message === 'invalid algorithm') {
 				throw new Error('Token Algorithm in not encoded in a supported format');
 			}
@@ -77,7 +77,7 @@ class SSOToken {
 			CLAIM_INSTANCE_ID: decoded.instance_id || null,
 			CLAIM_INSTANCE_NAME: decoded.instance_name || null,
 			CLAIM_USER_ID: decoded.sub || null,
-			CLAIM_USER_EXTERNAL_ID: decoded.external_Id || null,
+			CLAIM_USER_EXTERNAL_ID: decoded.external_id || null,
 			CLAIM_USER_FULL_NAME: decoded.name || null,
 			CLAIM_USER_FIRST_NAME: decoded.given_name || null,
 			CLAIM_USER_LAST_NAME: decoded.family_name || null,

--- a/src/lib/SSOTokenData.js
+++ b/src/lib/SSOTokenData.js
@@ -20,7 +20,7 @@ class SSOTokenData {
 		this.instance_id = tokenVals.CLAIM_INSTANCE_ID;
 		this.instance_name = tokenVals.CLAIM_INSTANCE_NAME;
 		this.sub = tokenVals.CLAIM_USER_ID;
-		this.external_Id = tokenVals.CLAIM_USER_EXTERNAL_ID;
+		this.external_id = tokenVals.CLAIM_USER_EXTERNAL_ID;
 		this.name = tokenVals.CLAIM_USER_FULL_NAME;
 		this.given_name = tokenVals.CLAIM_USER_FIRST_NAME;
 		this.family_name = tokenVals.CLAIM_USER_LAST_NAME;
@@ -110,7 +110,7 @@ class SSOTokenData {
 			instance_id: this.instance_id,
 			instance_name: this.instance_name,
 			sub: this.sub,
-			external_Id: this.external_Id,
+			external_id: this.external_id,
 			name: this.name,
 			given_name: this.given_name,
 			family_name: this.family_name,
@@ -136,7 +136,7 @@ class SSOTokenData {
 			CLAIM_INSTANCE_ID: this.instance_id,
 			CLAIM_INSTANCE_NAME: this.instance_name,
 			CLAIM_USER_ID: this.sub,
-			CLAIM_USER_EXTERNAL_ID: this.external_Id,
+			CLAIM_USER_EXTERNAL_ID: this.external_id,
 			CLAIM_USER_FULL_NAME: this.name,
 			CLAIM_USER_FIRST_NAME: this.given_name,
 			CLAIM_USER_LAST_NAME: this.family_name,

--- a/src/lib/SSOTokenData.js
+++ b/src/lib/SSOTokenData.js
@@ -17,19 +17,19 @@ class SSOTokenData {
 		this.nbf = tokenVals.CLAIM_NOT_BEFORE;
 		this.iat = tokenVals.CLAIM_ISSUED_AT;
 		this.iss = tokenVals.CLAIM_ISSUER;
-		this.instanceId = tokenVals.CLAIM_INSTANCE_ID;
-		this.instanceName	= tokenVals.CLAIM_INSTANCE_NAME;
+		this.instance_id = tokenVals.CLAIM_INSTANCE_ID;
+		this.instance_name = tokenVals.CLAIM_INSTANCE_NAME;
 		this.sub = tokenVals.CLAIM_USER_ID;
-		this.externalId = tokenVals.CLAIM_USER_EXTERNAL_ID;
+		this.external_Id = tokenVals.CLAIM_USER_EXTERNAL_ID;
 		this.name = tokenVals.CLAIM_USER_FULL_NAME;
-		this.givenName = tokenVals.CLAIM_USER_FIRST_NAME;
-		this.familyName = tokenVals.CLAIM_USER_LAST_NAME;
+		this.given_name = tokenVals.CLAIM_USER_FIRST_NAME;
+		this.family_name = tokenVals.CLAIM_USER_LAST_NAME;
 		this.role = tokenVals.CLAIM_USER_ROLE;
 		this.type = tokenVals.CLAIM_ENTITY_TYPE;
-		this.themingText = tokenVals.CLAIM_THEME_TEXT_COLOR;
-		this.themingBg = tokenVals.CLAIM_THEME_BACKGROUND_COLOR;
+		this.theming_text = tokenVals.CLAIM_THEME_TEXT_COLOR;
+		this.theming_bg = tokenVals.CLAIM_THEME_BACKGROUND_COLOR;
 		this.locale = tokenVals.CLAIM_USER_LOCALE;
-		this.tags		= tokenVals.USER_TAGS;
+		this.tags = tokenVals.USER_TAGS;
 	}
 
 	/**
@@ -43,7 +43,7 @@ class SSOTokenData {
 	 * if no callback is specified.
 	 */
 	getSigned(secret, cb) {
-		if(secret && typeof secret !== 'string') {
+		if (secret && typeof secret !== 'string') {
 			if (!cb) {
 				throw new Error('Secret must be a string value');
 			}
@@ -64,7 +64,7 @@ class SSOTokenData {
 				return jwt.sign(this.toJSObj(), secret, {algorithm: 'RS256'});
 			}
 			jwt.sign(this.toJSObj(), secret, {algorithm: 'RS256'}, cb);
-		} catch(err) {
+		} catch (err) {
 			console.log('error in signing jdk', err);
 			// throw new Error(err);
 		}
@@ -107,17 +107,17 @@ class SSOTokenData {
 			nbf: this.nbf,
 			iat: this.iat,
 			iss: this.iss,
-			instanceId: this.instanceId,
-			instanceName: this.instanceName,
+			instance_id: this.instance_id,
+			instance_name: this.instance_name,
 			sub: this.sub,
-			externalId: this.externalId,
+			external_Id: this.external_Id,
 			name: this.name,
-			givenName: this.givenName,
-			familyName: this.familyName,
+			given_name: this.given_name,
+			family_name: this.family_name,
 			role: this.role,
 			type: this.type,
-			themingText: this.themingText,
-			themingBg: this.themingBg,
+			theming_text: this.theming_text,
+			theming_bg: this.theming_bg,
 			locale: this.locale,
 			tags: this.tags,
 		};
@@ -133,17 +133,17 @@ class SSOTokenData {
 			CLAIM_NOT_BEFORE: this.nbf,
 			CLAIM_ISSUED_AT: this.iat,
 			CLAIM_ISSUER: this.iss,
-			CLAIM_INSTANCE_ID: this.instanceId,
-			CLAIM_INSTANCE_NAME: this.instanceName,
+			CLAIM_INSTANCE_ID: this.instance_id,
+			CLAIM_INSTANCE_NAME: this.instance_name,
 			CLAIM_USER_ID: this.sub,
-			CLAIM_USER_EXTERNAL_ID: this.externalId,
+			CLAIM_USER_EXTERNAL_ID: this.external_Id,
 			CLAIM_USER_FULL_NAME: this.name,
-			CLAIM_USER_FIRST_NAME: this.givenName,
-			CLAIM_USER_LAST_NAME: this.familyName,
+			CLAIM_USER_FIRST_NAME: this.given_name,
+			CLAIM_USER_LAST_NAME: this.family_name,
 			CLAIM_USER_ROLE: this.role,
 			CLAIM_ENTITY_TYPE: this.type,
-			CLAIM_THEME_TEXT_COLOR: this.themingText,
-			CLAIM_THEME_BACKGROUND_COLOR: this.themingBg,
+			CLAIM_THEME_TEXT_COLOR: this.theming_text,
+			CLAIM_THEME_BACKGROUND_COLOR: this.theming_bg,
 			CLAIM_USER_LOCALE: this.locale,
 			USER_TAGS: this.tags,
 		};

--- a/src/tests/SSOToken.test.js
+++ b/src/tests/SSOToken.test.js
@@ -50,95 +50,122 @@ let encodedTokenWithKey = SSOTokenDataObj.getSigned(keyTokenPriv); // Get signed
 
 describe('Testing SSOToken Class', () => {
     describe('Testing SSOToken Constructor', () => {
-      test('test token constructor with undefined params', () => {
-          expect( () => {
-              new SSOToken();
-          }).toThrow('Audience null or not specified');
-      });
+        test('test token constructor with undefined params', () => {
+            expect(() => {
+                new SSOToken();
+            }).toThrow('Audience null or not specified');
+        });
 
-      describe('Testing Token constructor App Secret cases', () => {
-          test('test token constructor with App Secret as null', () => {
-              expect( () => {
-                  new SSOToken(null, wrongTokenData, correctAudience);
-              }).toThrowError('Audience null or not specified');
-          });
-          test('test token constructor with non String value for App Secret', () => {
-              expect( () => {
-                  new SSOToken({test: 1}, wrongTokenData, correctAudience);
-              }).toThrowError('Audience must be a string value');
-          });
-          test('test token constructor with App Secret as empty string value', () => {
-              expect( () => {
-                  new SSOToken('', wrongTokenData, correctAudience);
-              }).toThrowError('Audience cannot be an empty string');
-          });
-      });
+        describe('Testing Token constructor App Secret cases', () => {
+            test('test token constructor with App Secret as null', () => {
+                expect(() => {
+                    new SSOToken(null, wrongTokenData, correctAudience);
+                }).toThrowError('Audience null or not specified');
+            });
+            test('test token constructor with non String value for App Secret', () => {
+                expect(() => {
+                    new SSOToken({test: 1}, wrongTokenData, correctAudience);
+                }).toThrowError('Audience must be a string value');
+            });
+            test('test token constructor with App Secret as empty string value', () => {
+                expect(() => {
+                    new SSOToken('', wrongTokenData, correctAudience);
+                }).toThrowError('Audience cannot be an empty string');
+            });
+        });
 
-      describe('Testing Token Constructor TokenData cases', () => {
-          test('test token constructor with token encoded by unsupported algorithm', () => {
-            expect( () => {
-              new SSOToken(correctAudience, keyTokenPub, encodedTokenWrongAlgo);
-            }).toThrowError('Token Algorithm in not encoded in a supported format');
-          });
-          test('test token constructor with TokenData as null', () => {
-              expect( () => {
-                  new SSOToken(correctAudience, keyTokenPub, null);
-              }).toThrowError('Token Data null or not specified');
-          });
-          test('test token constructor with non String value for Token Data', () => {
-              expect( () => {
-                  new SSOToken(correctAudience, keyTokenPub, {nonString: true});
-              }).toThrowError('Token Data must be a string value');
-          });
-          test('test token constructor with Token Data as empty string value', () => {
-              expect( () => {
-                  new SSOToken(correctAudience, keyTokenPub, '');
-              }).toThrowError('Token Data cannot be an empty string');
-          });
-          test('test token constructor unable to decode token', () => {
-              expect( () => {
-                  new SSOToken(correctAudience, keyTokenPub, wrongTokenData);
-              }).toThrow();
-          });
-          test('test token constructor with wrong jwt secret public key file', () => {
-              expect( () => {
-                  new SSOToken(correctAudience, 'bad secret', encodedTokenWithKey);
-              }).toThrowError('Unable to read public key');
-          });
-          test('test token constructor with expired token', () => {
-              expect( () => {
-                  new SSOToken(correctAudience, testTokenSecret, encodedTokenExp);
-              }).toThrow();
-          });
-      });
-      describe('Testing Token Constructor Audience cases', () => {
-        test('test token constructor with Audience as null', () => {
-            expect( () => {
-                new SSOToken(null, keyTokenPub, encodedTokenWithKey);
-            }).toThrowError('Audience null or not specified');
+        describe('Testing Token Constructor TokenData cases', () => {
+            test('test token constructor with token encoded by unsupported algorithm', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, keyTokenPub, encodedTokenWrongAlgo);
+                }).toThrowError('Token Algorithm in not encoded in a supported format');
+            });
+            test('test token constructor with TokenData as null', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, keyTokenPub, null);
+                }).toThrowError('Token Data null or not specified');
+            });
+            test('test token constructor with non String value for Token Data', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, keyTokenPub, {nonString: true});
+                }).toThrowError('Token Data must be a string value');
+            });
+            test('test token constructor with Token Data as empty string value', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, keyTokenPub, '');
+                }).toThrowError('Token Data cannot be an empty string');
+            });
+            test('test token constructor unable to decode token', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, keyTokenPub, wrongTokenData);
+                }).toThrow();
+            });
+            test('test token constructor with wrong jwt secret public key file', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, 'bad secret', encodedTokenWithKey);
+                }).toThrowError('Unable to read public key');
+            });
+            test('test token constructor with expired token', () => {
+                expect(() => {
+                    new SSOToken(correctAudience, testTokenSecret, encodedTokenExp);
+                }).toThrow();
+            });
         });
-        test('test token constructor with non String value for Audience', () => {
-            expect( () => {
-                new SSOToken({nonStringAud: true}, keyTokenPub, encodedTokenWithKey);
-            }).toThrowError('Audience must be a string value');
+        describe('Testing Token Constructor Audience cases', () => {
+            test('test token constructor with Audience as null', () => {
+                expect(() => {
+                    new SSOToken(null, keyTokenPub, encodedTokenWithKey);
+                }).toThrowError('Audience null or not specified');
+            });
+            test('test token constructor with non String value for Audience', () => {
+                expect(() => {
+                    new SSOToken({nonStringAud: true}, keyTokenPub, encodedTokenWithKey);
+                }).toThrowError('Audience must be a string value');
+            });
+            test('test token constructor with Audience as empty string value', () => {
+                expect(() => {
+                    new SSOToken('', keyTokenPub, encodedTokenWithKey);
+                }).toThrowError('Audience cannot be an empty string');
+            });
+            test('test token constructor with wrong Audience valie', () => {
+                expect(() => {
+                    new SSOToken(wrongAudience, keyTokenPub, encodedTokenWithKey);
+                }).toThrowError('Incorrect audience value');
+            });
         });
-        test('test token constructor with Audience as empty string value', () => {
-            expect( () => {
-                new SSOToken('', keyTokenPub, encodedTokenWithKey);
-            }).toThrowError('Audience cannot be an empty string');
+        test('test token constructor with token data correctly decoded', () => {
+            expect(() => {
+                // use public key to verify key
+                let newToken = new SSOToken(correctAudience, keyTokenPub, encodedTokenWithKey);
+                return newToken;
+            }).not.toThrow();
         });
-        test('test token constructor with wrong Audience valie', () => {
-          expect( () => {
-            new SSOToken(wrongAudience, keyTokenPub, encodedTokenWithKey);
-          }).toThrowError('Incorrect audience value');
-        });
-      });
-      test('test token constructor with token data correctly decoded', () => {
-          expect( () => {
-            // use public key to verify key
+
+        test('test token constructor with token data correctly decoded with all values', () => {
             let newToken = new SSOToken(correctAudience, keyTokenPub, encodedTokenWithKey);
-            return newToken;
-          }).not.toThrow();
-      });
+            const expected = {
+                aud: 'testPlugin',
+                exp: expTime,
+                instance_id: '55c79b6ee4b06c6fb19bd1e2',
+                family_name: 'Doe',
+                given_name: 'John',
+                external_Id: 'jdoe',
+                iat: curTime,
+                instance_id: '55c79b6ee4b06c6fb19bd1e2',
+                instance_name: 'Our locations',
+                iss: 'api.staffbase.com',
+                locale: 'en-US',
+                name: 'John Doe',
+                nbf: notBeforeTime,
+                role: 'editor',
+                sub: '541954c3e4b08bbdce1a340a',
+                tags: null,
+                theming_bg: '#FFAABB',
+                theming_text: '#00ABAB',
+                type: 'type',
+            };
+
+            expect(newToken.getTokenData()).toEqual(expected);
+        });
     });
 });

--- a/src/tests/SSOToken.test.js
+++ b/src/tests/SSOToken.test.js
@@ -149,7 +149,7 @@ describe('Testing SSOToken Class', () => {
                 instance_id: '55c79b6ee4b06c6fb19bd1e2',
                 family_name: 'Doe',
                 given_name: 'John',
-                external_Id: 'jdoe',
+                external_id: 'jdoe',
                 iat: curTime,
                 instance_id: '55c79b6ee4b06c6fb19bd1e2',
                 instance_name: 'Our locations',


### PR DESCRIPTION
The data generator had camel cased key names, while the decoded values are snake cased. This results in failing errors, if the library is used to test its own tokens.

This fixes also the casing of external_id, which seems to never has worked. 

test plan:

- code review