### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3962,26 +3962,26 @@
       }
     },
     "node_modules/dmd": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.0.0.tgz",
-      "integrity": "sha512-PwWZlqZnJPETwqZZ70haRa+UDZcD5jeBD3ywW1Kf+jYYv0MHu/S7Ri9jsSoeTMwkcMVW9hXOMA1IZUMEufBhOg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.1.0.tgz",
+      "integrity": "sha512-0zQIJ873gay1scCTFZvHPWM9mVJBnaylB2NQDI8O9u8O32m00Jb6uxDKexZm8hjTRM7RiWe0FJ32pExHoXdwoQ==",
       "dev": true,
       "dependencies": {
-        "array-back": "^5.0.0",
+        "array-back": "^6.2.2",
         "cache-point": "^2.0.0",
-        "common-sequence": "^2.0.0",
-        "file-set": "^4.0.1",
+        "common-sequence": "^2.0.2",
+        "file-set": "^4.0.2",
         "handlebars": "^4.7.7",
-        "marked": "^2.0.0",
+        "marked": "^4.0.12",
         "object-get": "^2.1.1",
-        "reduce-flatten": "^3.0.0",
+        "reduce-flatten": "^3.0.1",
         "reduce-unique": "^2.0.1",
         "reduce-without": "^1.0.1",
         "test-value": "^3.0.0",
-        "walk-back": "^5.0.0"
+        "walk-back": "^5.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/dmd-bitbucket": {
@@ -3991,6 +3991,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dmd/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/dmd/node_modules/reduce-flatten": {
@@ -7542,18 +7551,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jsdoc/node_modules/marked": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -7906,15 +7903,15 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/mdurl": {
@@ -12678,25 +12675,31 @@
       "dev": true
     },
     "dmd": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.0.0.tgz",
-      "integrity": "sha512-PwWZlqZnJPETwqZZ70haRa+UDZcD5jeBD3ywW1Kf+jYYv0MHu/S7Ri9jsSoeTMwkcMVW9hXOMA1IZUMEufBhOg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.1.0.tgz",
+      "integrity": "sha512-0zQIJ873gay1scCTFZvHPWM9mVJBnaylB2NQDI8O9u8O32m00Jb6uxDKexZm8hjTRM7RiWe0FJ32pExHoXdwoQ==",
       "dev": true,
       "requires": {
-        "array-back": "^5.0.0",
+        "array-back": "^6.2.2",
         "cache-point": "^2.0.0",
-        "common-sequence": "^2.0.0",
-        "file-set": "^4.0.1",
+        "common-sequence": "^2.0.2",
+        "file-set": "^4.0.2",
         "handlebars": "^4.7.7",
-        "marked": "^2.0.0",
+        "marked": "^4.0.12",
         "object-get": "^2.1.1",
-        "reduce-flatten": "^3.0.0",
+        "reduce-flatten": "^3.0.1",
         "reduce-unique": "^2.0.1",
         "reduce-without": "^1.0.1",
         "test-value": "^3.0.0",
-        "walk-back": "^5.0.0"
+        "walk-back": "^5.1.0"
       },
       "dependencies": {
+        "array-back": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+          "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+          "dev": true
+        },
         "reduce-flatten": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
@@ -15285,12 +15288,6 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
-        },
-        "marked": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-          "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
-          "dev": true
         }
       }
     },
@@ -15663,9 +15660,9 @@
       "requires": {}
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true
     },
     "mdurl": {


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [7.24.2](https://github.com/npm/cli/releases/tag/v7.24.2).

<details open>
<summary><strong>Updated (2)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [dmd](https://www.npmjs.com/package/dmd/v/6.1.0) | `6.0.0` → `6.1.0` | [github](https://github.com/jsdoc2md/dmd) | - |
| [marked](https://www.npmjs.com/package/marked/v/4.0.12) | `2.1.3` → `4.0.12` | [github](https://github.com/markedjs/marked) | **[High]** Inefficient Regular Expression Complexity in marked ([ref](https://github.com/advisories/GHSA-5v2h-r2cx-5xgj)) |

</details>

<details open>
<summary><strong>Added (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [array-back](https://www.npmjs.com/package/array-back/v/6.2.2) (`dmd/node_modules/array-back`) | `6.2.2` | [github](https://github.com/75lb/array-back) | - |

</details>

<details open>
<summary><strong>Removed (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [marked](https://www.npmjs.com/package/marked/v/4.0.10) (`jsdoc/node_modules/marked`) | `4.0.10` | [github](https://github.com/markedjs/marked) | - |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)