### PR TITLE
chore: added support for branch ID & slug in SSO data

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,6 +78,8 @@ The following data can be retrieved from the token:
 
 |Helper Name|Token Key| Fetch Function| Description|
 | --- | --- | --- | --- |
+|CLAIM_BRANCH_ID|branch_id|getBranchId()|Get the branch ID for which the token was issued.|
+|CLAIM_BRANCH_SLUG|branch_slug|getBranchSlug()|Get the branch slug for which the token was issued.|
 |CLAIM_AUDIENCE|aud|getAudience()|Get targeted audience of the token.|
 |CLAIM_EXPIRE_AT|exp|getExpireAtTime()|Get the time when the token expires.|
 |CLAIM_NOT_BEFORE|nbf|getNotBeforeTime()|Get the time when the token starts to be valid.|
@@ -180,10 +182,9 @@ To run the tests a simple `# npm test` command in the root directory will suffic
 
 ## License
 
-Copyright 2017-2021 Staffbase GmbH.
+Copyright 2017-2023 Staffbase GmbH.
 
 Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0
-
 
 <table>
   <tr>

--- a/docs/API.MD
+++ b/docs/API.MD
@@ -35,6 +35,8 @@ SSOTokenData Class used to host the token data values and provide getter functio
     * [.toJSObj()](#markdown-header-ssotokendatatojsobj-object) ⇒ Object
     * [.toJSObjPretty()](#markdown-header-ssotokendatatojsobjpretty-object) ⇒ Object
     * [._getClaim(claimName)](#markdown-header-ssotokendata_getclaimclaimname-stringnumbernull) ⇒ String ⎮ number ⎮ null
+    * [.getBranchId()](#markdown-header-ssotokendatagetbranchid-nullstring) ⇒ null ⎮ string
+    * [.getBranchSlug()](#markdown-header-ssotokendatagetbranchslug-nullstring) ⇒ null ⎮ string
     * [.getAudience()](#markdown-header-ssotokendatagetaudience-nullstring) ⇒ null ⎮ string
     * [.getExpireAtTime()](#markdown-header-ssotokendatagetexpireattime-number) ⇒ number
     * [.getNotBeforeTime()](#markdown-header-ssotokendatagetnotbeforetime-number) ⇒ number
@@ -110,6 +112,15 @@ Internally used to get value against the client param string.
 | --- | --- | --- |
 | claimName | String | The claim name as defined in the tokenDataConsts |
 
+**Kind**: instance method of [SSOTokenData](#markdown-header-new-ssotokendatatokenvals)
+### ssoTokenData.getBranchId() ⇒ null ⎮ string
+Get the branch ID for which the token was issued.
+
+**Kind**: instance method of [SSOTokenData](#markdown-header-new-ssotokendatatokenvals)  
+### ssoTokenData.getBranchSlug() ⇒ null ⎮ string
+Get the branch slug for which the token was issued.
+
+**Kind**: instance method of [SSOTokenData](#markdown-header-new-ssotokendatatokenvals)  
 ### ssoTokenData.getAudience() ⇒ null ⎮ string
 Get targeted audience of the token.
 

--- a/src/lib/SSOToken.js
+++ b/src/lib/SSOToken.js
@@ -77,6 +77,8 @@ class SSOToken {
     }
 
     const tokenDataInst = new TokenData({
+      CLAIM_BRANCH_ID: decoded.branch_id || null,
+      CLAIM_BRANCH_SLUG: decoded.branch_slug || null,
       CLAIM_AUDIENCE: decoded.aud || null,
       CLAIM_EXPIRE_AT: decoded.exp || null,
       CLAIM_NOT_BEFORE: decoded.nbf || null,

--- a/src/lib/SSOTokenData.js
+++ b/src/lib/SSOTokenData.js
@@ -12,6 +12,8 @@ class SSOTokenData {
    * @param  {Object} tokenVals TokenVals object wit keys representing possible SSO token values.
    */
   constructor(tokenVals) {
+    this.branch_id = tokenVals.CLAIM_BRANCH_ID;
+    this.branch_slug = tokenVals.CLAIM_BRANCH_SLUG;
     this.aud = tokenVals.CLAIM_AUDIENCE;
     this.exp = tokenVals.CLAIM_EXPIRE_AT;
     this.nbf = tokenVals.CLAIM_NOT_BEFORE;
@@ -106,6 +108,8 @@ class SSOTokenData {
    */
   toJSObj() {
     return {
+      branch_id: this.branch_id,
+      branch_slug: this.branch_slug,
       aud: this.aud,
       exp: this.exp,
       nbf: this.nbf,
@@ -134,6 +138,8 @@ class SSOTokenData {
    */
   toJSObjPretty() {
     return {
+      CLAIM_BRANCH_ID: this.branch_id,
+      CLAIM_BRANCH_SLUG: this.branch_slug,
       CLAIM_AUDIENCE: this.aud,
       CLAIM_EXPIRE_AT: this.exp,
       CLAIM_NOT_BEFORE: this.nbf,
@@ -167,6 +173,24 @@ class SSOTokenData {
     }
     return this[TokenDataConsts[claimName]] || null;
   }
+  /**
+   * Get the branch ID for which the token was issued.
+   *
+   * @return {null|string}
+   */
+  getBranchId() {
+    return this._getClaim('CLAIM_BRANCH_ID');
+  }
+
+  /**
+   * Get the branch slug for which the token was issued.
+   *
+   * @return {null|string}
+   */
+  getBranchSlug() {
+    return this._getClaim('CLAIM_BRANCH_SLUG');
+  }
+
   /**
    * Get targeted audience of the token.
    *

--- a/src/tests/SSOToken.test.js
+++ b/src/tests/SSOToken.test.js
@@ -17,6 +17,8 @@ const correctAudience = 'testPlugin';
 const wrongAudience = 'wrongIssuer';
 
 const tokenDataVals = {
+  CLAIM_BRANCH_ID: '5e3bfa789f436c5e2ee5141a',
+  CLAIM_BRANCH_SLUG: 'staffbase',
   CLAIM_AUDIENCE: 'testPlugin',
   CLAIM_EXPIRE_AT: expTime,
   CLAIM_NOT_BEFORE: notBeforeTime,
@@ -146,6 +148,8 @@ describe('Testing SSOToken Class', () => {
     test('test token constructor with token data correctly decoded with all values', () => {
       const newToken = new SSOToken(correctAudience, keyTokenPub, encodedTokenWithKey);
       const expected = {
+        branch_id: '5e3bfa789f436c5e2ee5141a',
+        branch_slug: 'staffbase',
         aud: 'testPlugin',
         exp: expTime,
         instance_id: '55c79b6ee4b06c6fb19bd1e2',

--- a/src/tests/SSOTokenData.test.js
+++ b/src/tests/SSOTokenData.test.js
@@ -9,6 +9,8 @@ const notBeforeTime = curTime - (1000 * 60);
 const secretPub = fs.readFileSync(path.join(__dirname, '../../testKeyFiles/jwtRS256.key')).toString();
 
 const tokenDataVals = {
+  CLAIM_BRANCH_ID: '5e3bfa789f436c5e2ee5141a',
+  CLAIM_BRANCH_SLUG: 'staffbase',
   CLAIM_AUDIENCE: 'testPlugin',
   CLAIM_EXPIRE_AT: expTime,
   CLAIM_NOT_BEFORE: notBeforeTime,

--- a/src/utils/tokenDataConsts.js
+++ b/src/utils/tokenDataConsts.js
@@ -1,4 +1,6 @@
 const constants = {
+  CLAIM_BRANCH_ID: 'branch_id',
+  CLAIM_BRANCH_SLUG: 'branch_slug',
   CLAIM_AUDIENCE: 'aud',
   CLAIM_EXPIRE_AT: 'exp',
   CLAIM_NOT_BEFORE: 'nbf',


### PR DESCRIPTION
To align with our PHP and JAVA SDK. The backend already provides this info, but the NodeJS SDK did not implement them yet.