### PR TITLE
edits to enable trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,6 +2,9 @@ name: Publish to NPM Registry
 on:
   release:
     types: [created]
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,22 +6,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          registry-url: 'https://registry.npmjs.org'
-  
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Install dependencies
         run: npm install
 
       - name: Create build
         run: npm run build
 
-      - name: Publish package on NPM 📦        
+      - name: Publish package on NPM 📦
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Added updates to enable OIDC based trusted publishing for this repository.
This is based on this ticket: https://mitarbeiterapp.atlassian.net/browse/CI-921