### PR TITLE
fix(dependabot): fix broken config and add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  npm-github:
-    type: npm-registry
-    url: https://npm.pkg.github.com
-    token: ${{secrets.STAFFBOT_NPM_READ}}
-
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -14,5 +8,14 @@ updates:
       default-days: 7
     labels:
       - "dependencies"
-    registries:
-      - npm-github
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       default-days: 7
     labels:
       - "dependencies"
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Tickets

- CI-1040: Allow dependabot to pull internal packages and actions
- CI-1108: Adopt cooldown to mitigate supply-chain attacks (background)

## What

- Remove private registry config for `npm.pkg.github.com` — internal NPM packages are now accessible to Dependabot without a token since the relevant repos were made internal (CI-1040)
- Add `github-actions` ecosystem so Dependabot can update internal GitHub Actions
- Add `cooldown: default-days: 7` to both ecosystems to mitigate supply-chain attacks (CI-1108)

---
*This PR was created with [opencode](https://opencode.ai) using Claude Sonnet 4.6.*