### PR TITLE
ACT-3722: update js-yaml to 3.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6081,9 +6081,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "node-rsa": "^1.1.1"
   },
   "overrides": {
-    "cross-spawn": ">=7.0.6"
+    "cross-spawn": ">=7.0.6",
+    "js-yaml@<3.15.0": "3.15.0"
   }
 }


### PR DESCRIPTION
## Corresponding ticket

- ACT-3722
- Dependabot alert #62 / GHSA-h67p-54hq-rp68

## What changed

- Added a range-scoped npm override that raises vulnerable `js-yaml` 3.x versions to 3.15.0.
- Refreshed only the single transitive `js-yaml` lock entry from 3.14.2 to 3.15.0.
- The ancestry remains `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config` → `js-yaml`.

## Verification

- `npm ci` on Node 24
- `npm run lint`
- `npm run test:coverage -- --runInBand`: 6 suites / 158 tests passed
- `npm run readme`: generated documentation remains clean
- `npm pack --dry-run --json`: package contents validated
- Installed graph contains only `js-yaml` 3.15.0

A bounded repeated-alias regression used a 33.9 KB YAML document. Version 3.14.2 spent about 3.1 seconds processing the redundant merges, while 3.15.0 rejected the payload in about 33 ms at the `maxTotalMergeKeys` limit. This dependency is development-only and not shipped in the SDK package, so residual runtime risk is low after merge.
