### PR TITLE
ACT-3680: remediate linkify-it vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6378,10 +6378,20 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -6508,15 +6518,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"


### PR DESCRIPTION
## Summary

- update the transitive documentation toolchain from `markdown-it` 14.1.1 to 14.3.0
- resolve `linkify-it` to 5.0.2, fixing GHSA-22p9-wv53-3rq4 and GHSA-v245-v573-v5vm
- remove the related `markdown-it` moderate finding, GHSA-6v5v-wf23-fmfq
- supersede #106: its 14.2.0 lockfile update resolves only `linkify-it` 5.0.1, which remains affected by GHSA-v245-v573-v5vm

## Scope

This is development-only documentation tooling (`jsdoc-to-markdown` → `jsdoc` → `markdown-it`); no SDK runtime source changes are included.

## Validation

- Node 20, 22, and 24: `npm ci`, build, lint, and 158 Jest tests
- Node 20 and 24: coverage (99.39% lines)
- bounded `linkify-it` / `markdown-it` parser smoke
- packed SDK clean-consumer install and import
- composed locally with #115: clean merge, exact-head ancestry, zero-vulnerability `npm audit`, and byte-identical packed public artifacts