### PR TITLE
ACT-3680: publish SDK 1.3.9 correctly

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,7 +19,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
+
+      - name: Verify package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: test "$(node -p "require('./package.json').version")" = "$RELEASE_TAG"
 
       - name: Create build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staffbase/staffbase-plugin-sdk",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staffbase/staffbase-plugin-sdk",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "license": "ISC",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staffbase/staffbase-plugin-sdk",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Staffbase Plugin SDK for Javascript / Node.js",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
## What

- Align the package manifest and lockfile with the existing 1.3.9 release tag.
- Use a frozen install in the publish workflow.
- Fail the publish workflow when the release tag and package version differ.

## Verification

- `npm ci`
- `npm run lint`
- `npm test`
- `npm pack --dry-run --json`
- Verified the version guard passes for 1.3.9 and rejects a mismatch.