### PR TITLE
chore: align dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: monday
     cooldown:
       default-days: 7
     labels:
       - "dependencies"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: monday
     labels:
       - "dependencies"
     cooldown:


### PR DESCRIPTION
- What changed: set Dependabot schedules to weekly on monday.
- Why: align cadence across CC team-owned repos.
- Validation: reviewed .github/dependabot.yml changes only.